### PR TITLE
React Native 56 support

### DIFF
--- a/jest-preset.json
+++ b/jest-preset.json
@@ -15,8 +15,7 @@
     "^React$": "<rootDir>/node_modules/react"
   },
   "modulePathIgnorePatterns": [
-    "<rootDir>/node_modules/react-native/Libraries/react-native/",
-    "<rootDir>/node_modules/react-native/packager/"
+    "<rootDir>/node_modules/react-native/Libraries/react-native/"
   ],
   "transformIgnorePatterns": [
     "node_modules/(?!(jest-)?react-native|react-clone-referenced-element|react-native|react-navigation)"
@@ -34,7 +33,7 @@
     "json"
   ],
   "transform": {
-    "^.+\\.(js|jsx)$": "<rootDir>/node_modules/babel-jest",
+    "^.+\\.js$": "<rootDir>/node_modules/react-native/jest/preprocessor.js",
     "^.+\\.(ts|tsx)$": "<rootDir>/node_modules/jest-preset-ignite/preprocessor.js"
   },
   "testMatch": [

--- a/jest-preset.json
+++ b/jest-preset.json
@@ -8,7 +8,8 @@
     ],
     "providesModuleNodeModules": [
       "react-native"
-    ]
+    ],
+    "hasteImplModulePath": "<rootDir>/node_modules/react-native/jest/hasteImpl.js"
   },
   "moduleNameMapper": {
     "^[./a-zA-Z0-9$_-]+\\.(bmp|gif|jpg|jpeg|png|psd|svg|webp|ttf|otf)$": "RelativeImageStub",


### PR DESCRIPTION
This adds `react-native@0.56.0` support.

Not quite sure how to deal with publishing this since it's going to change again in `0.57.0` once that lands.

I'll leave here so people can use tho.  Update your `package.json` to point to this branch short term.

```
"jest-preset-ignite": "infinitered/jest-preset-ignite#rn56"
```