### PR TITLE
📌 pins 0.6.1 to jest 23.6+ and ts 3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Version 0.6 of this library supports:
 
 | Library      | Version    |
 | ------------ | ---------- |
-| Jest         | 23.x       |
+| Jest         | 23.6.x     |
 | React Native | 0.56, 0.57 |
 | TypeScript   | 3.x        |
 | Node JS      | 8+         |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-preset-ignite",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Jest preset for handling TypeScript on a React Native project.",
   "license": "MIT",
   "author": "Steve Kellock <steve@kellock.ca>",
@@ -20,8 +20,8 @@
   ],
   "peerDependencies": {
     "react-native": ">=0.56.0",
-    "jest": "^22.4.2 || ^23",
-    "typescript": "^2.7 || ^3"
+    "jest": "^23.6",
+    "typescript": "^3"
   },
   "devDependencies": {
     "prettier": "^1.14.3"


### PR DESCRIPTION
Needed to be really specific here... turns out this doesn't work on `jest 23.2`.  😆 

cc @ryanlntn
