### PR TITLE
Add react-navigation v3 to transformIgnorePatterns

### DIFF
--- a/jest-preset.json
+++ b/jest-preset.json
@@ -19,7 +19,7 @@
     "<rootDir>/node_modules/react-native/Libraries/react-native/"
   ],
   "transformIgnorePatterns": [
-    "node_modules/(?!(jest-)?react-native|react-clone-referenced-element|react-native|react-navigation)"
+    "node_modules/(?!(jest-)?react-native|react-clone-referenced-element|react-native|react-navigation|@react-navigation)"
   ],
   "setupFiles": [
     "<rootDir>/node_modules/react-native/jest/setup.js",


### PR DESCRIPTION
Same as https://github.com/infinitered/jest-preset-ignite/pull/1, but for `react-navigation` v3.

>In v3, all of our main packages and repos are separated. There are the following core packages in our new NPM org:
> - @react-navigation/core - The primitives and utilities that define our patterns, plus several routers
> - @react-navigation/native - Container and support for navigators on React Native apps. createAppContainer from the main react-navigation package actually comes from this package.
> - @react-navigation/web - Web browser app container, and utilities for server rendering

Add `@react-navigation` to `transformIgnorePatterns` in `json-preset.json`
to resolve:

```
({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){import React from 'react';
                                                                                             ^^^^^^

    SyntaxError: Unexpected token import
```