### PR TITLE
Fix jest peer dependency warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "peerDependencies": {
     "react-native": ">=0.56.0",
-    "jest": "^23.6",
+    "jest": "^24.7",
     "typescript": "^3"
   },
   "devDependencies": {


### PR DESCRIPTION
Should fix `warning " > jest-preset-ignite@0.6.1" has incorrect peer dependency "jest@^23.6".`